### PR TITLE
Add grouped Dependabot config for uv/pip (#13)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  - package-ecosystem: uv
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    # uv groups do not support dependency-type; use patterns (first match wins).
+    groups:
+      dev-tools:
+        patterns:
+          - "black"
+          - "isort"
+          - "pytest"
+          - "nox"
+          - "auto-py-to-exe"
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.issueflows/03-solved-issues/issue13_original.md
+++ b/.issueflows/03-solved-issues/issue13_original.md
@@ -1,0 +1,16 @@
+# Issue #13: Add grouped Dependabot config for uv/pip
+
+Source: https://github.com/ife-bat/oeleo/issues/13
+
+## Original issue text
+
+## Summary
+Add `.github/dependabot.yml` (or equivalent) so dependency bumps arrive as grouped PRs and security alerts do not pile up again.
+
+**Finding ID:** DEP-03  
+**Size:** yolo-fit  
+**Design doc:** `.issueflows/04-designs-and-guides/code-review-dependabot.md`
+
+## Acceptance
+- [ ] Dependabot (or equivalent) configured for the pip/uv ecosystem
+- [ ] Prefer grouped updates over one PR per transitive package

--- a/.issueflows/03-solved-issues/issue13_plan.md
+++ b/.issueflows/03-solved-issues/issue13_plan.md
@@ -1,0 +1,45 @@
+# Plan: Issue #13 — Grouped Dependabot config (DEP-03)
+
+## Goal
+
+Add `.github/dependabot.yml` so uv/pip dependency updates arrive as grouped PRs instead of one per transitive package.
+
+## Constraints
+
+- `uv` ecosystem only for lock updates — do not use `dependency-type` in groups (unsupported for uv).
+- Config-only change; no lock or pin edits in this PR.
+- Mark DEP-03 done in `code-review-dependabot.md`.
+
+### Prior art
+
+- None found (toolbox empty; no existing `dependabot.yml`).
+- Design: [`code-review-dependabot.md`](../04-designs-and-guides/code-review-dependabot.md).
+
+## Approach
+
+1. Create `.github/dependabot.yml` with:
+   - `package-ecosystem: uv`, `directory: /`, weekly schedule
+   - Groups via `patterns`: `dev-tools` (named dev deps) before `all-dependencies` (`*`) catch-all
+   - Optional `github-actions` ecosystem for workflow action bumps (grouped)
+2. Update dependabot design doc — DEP-03 status → done
+3. Sanity: `uv run pytest -m "not ssh"`
+
+## Files to touch
+
+| Path | Change |
+|------|--------|
+| `.github/dependabot.yml` | New grouped Dependabot config |
+| `.issueflows/04-designs-and-guides/code-review-dependabot.md` | DEP-03 marked done |
+| `.issueflows/01-current-issues/issue13_status.md` | Progress |
+
+## Test strategy
+
+```bash
+uv run pytest -m "not ssh"
+```
+
+No new unit tests (YAML config only).
+
+## Open questions
+
+None — straightforward config per acceptance criteria.

--- a/.issueflows/03-solved-issues/issue13_status.md
+++ b/.issueflows/03-solved-issues/issue13_status.md
@@ -1,0 +1,12 @@
+# Status: Issue #13
+
+- [ ] Done
+
+## What's done
+
+- Added `.github/dependabot.yml` with grouped `uv` and `github-actions` updates.
+- Updated `code-review-dependabot.md` — DEP-03 marked done.
+
+## Remaining work
+
+- Re-run tests; `/iflow-close yolo`.

--- a/.issueflows/04-designs-and-guides/code-review-dependabot.md
+++ b/.issueflows/04-designs-and-guides/code-review-dependabot.md
@@ -9,7 +9,7 @@ Snapshot date: **2026-07-16** (post-DEP-01 / DEP-02; re-check open alerts on Git
 |-------|-------|--------|
 | DEP-01 | [#11](https://github.com/ife-bat/oeleo/issues/11) — lock refresh + pin widen | **Done** (merged) |
 | DEP-02 | [#12](https://github.com/ife-bat/oeleo/issues/12) — residuals + `poetry.lock` | **Done** (this PR) |
-| DEP-03 | [#13](https://github.com/ife-bat/oeleo/issues/13) — grouped Dependabot config | Open |
+| DEP-03 | [#13](https://github.com/ife-bat/oeleo/issues/13) — grouped Dependabot config | **Done** (`.github/dependabot.yml`) |
 
 **Pre-DEP-01 (2026-07-16):** 29 open alerts (13 high, 13 medium, 3 low), mostly on `uv.lock`, blocked by `black<23` and `pytest<8`.
 
@@ -75,9 +75,9 @@ Widened `black` / `pytest` dev pins, raised `python-dotenv` floor, `uv lock --up
 | Stale `poetry.lock` | Absent on `main` — no deletion needed |
 | Recurring alerts | Deferred to DEP-03 ([#13](https://github.com/ife-bat/oeleo/issues/13)) |
 
-### DEP-03 — Dependabot config (open, [#13](https://github.com/ife-bat/oeleo/issues/13))
+### DEP-03 — Dependabot config ([#13](https://github.com/ife-bat/oeleo/issues/13)) — **Done**
 
-Add `.github/dependabot.yml` for grouped weekly `uv` / pip updates so alerts do not pile up again.
+`.github/dependabot.yml` configures weekly grouped updates for the `uv` lockfile (`dev-tools` pattern group + `all-dependencies` catch-all) and `github-actions`. uv groups use `patterns` only — not `dependency-type`.
 
 ## What not to do
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #13.

## Summary

Adds grouped Dependabot version updates for the `uv` lockfile and GitHub Actions, completing the DEP-03 track (after #11/#12).

## What changed

- **`.github/dependabot.yml`** — weekly updates with:
  - `uv` ecosystem: `dev-tools` pattern group (black, isort, pytest, nox, auto-py-to-exe) + `all-dependencies` catch-all
  - `github-actions` ecosystem: grouped action bumps
- **`code-review-dependabot.md`** — DEP-03 marked done

Note: the `uv` ecosystem does not support `dependency-type` in groups; pattern-based grouping is used instead.

## Test strategy

```bash
uv run pytest -m "not ssh"
```

20 passed, 3 deselected (config-only change).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6cd796d5-508f-4619-b064-554ad20c6559"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6cd796d5-508f-4619-b064-554ad20c6559"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

