### PR TITLE
Ensure connection when target is lost (#8)

### DIFF
--- a/.issueflows/01-current-issues/issue8_original.md
+++ b/.issueflows/01-current-issues/issue8_original.md
@@ -1,0 +1,9 @@
+# Issue #8: Ensure connection
+
+Source: https://github.com/ife-bat/oeleo/issues/8
+
+## Original issue text
+
+Seems like `oeleo` sometimes keeps on running even when the connection is lost to the target directory.
+
+- fix: check connection more often? crash if needed?

--- a/.issueflows/01-current-issues/issue8_plan.md
+++ b/.issueflows/01-current-issues/issue8_plan.md
@@ -1,0 +1,67 @@
+# Plan: Issue #8 — Ensure connection
+
+## Goal
+
+Stop oeleo from quietly continuing a transfer run when the **destination** connection is gone. Detect loss, report it, and abort the current run instead of marking every remaining file `!` and looping forever.
+
+## Constraints
+
+- Scope is **connection health for the external (destination) connector** during `Worker.run` / scheduled loops — not a full REL-02 connector-error rewrite (SSH list/checksum soft failures stay a follow-up).
+- Do not change tray quit / `die_if_necessary` → `sys.exit` (REL-04) in this PR.
+- Keep #17 behavior: default `reconnect=False`; failed moves still reconnect once and retry.
+- Public API stays composition-friendly (`Worker` + connectors); prefer a small Protocol method over ad-hoc checks only in `Worker`.
+- Unit tests via `uv run pytest -m "not ssh"`; no new Docker SSH requirement for the happy path.
+- Cite #8 / connection-ensure in status and a short design-doc note when closing.
+
+### Prior art
+
+- `OeleoConnectionError` — [`oeleo/connectors.py`](oeleo/connectors.py): already raised from `SSHConnector.reconnect` on close/connect failure.
+- `Connector` Protocol — `connect` / `reconnect` / `close` / `move_func`; no health probe today.
+- `SSHConnector._check_connection_and_exit` / `check_connection_and_exit` — debug-only probes that `sys.exit()`; keep as-is or leave unused (CLEAN-01); do **not** call from production path.
+- `Worker._process_file` — failed `move_func` → reconnect + retry → report `!` and continue; `_process_single_chunk` swallows exceptions into `failed_files`.
+- `SimpleScheduler.start` — infinite interval loop; only aborts via `die_if_necessary` (tray) or `max_run_intervals`.
+- `LocalConnector` / `simple_mover` — destination missing/unwritable → `False`, no abort.
+- Design: REL-02 / REL-04 in [`code-review-correctness-and-bugs.md`](.issueflows/04-designs-and-guides/code-review-correctness-and-bugs.md) — related but **not** this issue’s acceptance.
+- Toolbox: none. Graph: none.
+
+## Approach
+
+1. **Protocol probe** — Add `ensure_connection(self) -> None` on `Connector`. Success = no-op return; failure = raise `OeleoConnectionError` (reuse existing type).
+   - **LocalConnector:** destination `directory` must exist and be a directory (and ideally accessible — `os.access` / `stat`). Missing network mount / deleted folder → raise.
+   - **SSHConnector:** lightweight remote probe (reuse the find/dir idea from the debug helpers **without** `sys.exit`); treat Fabric/transport failure as connection lost.
+   - **SharePointConnector:** minimal probe (e.g. touch `self.connection.folder` / list once); Shareplum errors → raise. Keep small; no SharePoint rewrite.
+2. **Worker abort path** — Introduce a clear abort signal (raise `OeleoConnectionError` out of `run`, or a thin `OeleoAborted` alias — prefer reusing `OeleoConnectionError`):
+   - Call `external_connector.ensure_connection()` at the **start of `run()`**.
+   - After a failed move + reconnect-retry still fails, call `ensure_connection()` again; if that raises, **stop the run** (do not process remaining files). If the probe still passes, keep current per-file `!` behavior (file-level failure, connection OK).
+   - Notify via `reporter.report` / `reporter.notify` with a clear message before aborting.
+   - Ensure `_process_single_chunk` / `run` do **not** swallow `OeleoConnectionError` into “failed file and continue”.
+3. **Scheduler** — In `SimpleScheduler.start`, catch `OeleoConnectionError` around `filter_local`/`run`: report, then **skip to the next sleep interval** (recommended) so a transient outage does not kill the Windows scheduled app. Document that the process stays alive unless the operator uses tray quit.
+4. **Tests** — Mock external connector: (a) `ensure_connection` fails at run start → no `move_func`; (b) first moves succeed, then move fails and `ensure_connection` fails → remaining files not processed; (c) move fails but `ensure_connection` OK → continue with `!` for that file only.
+5. **Docs** — Short README / design note: destination loss aborts the current run; scheduler retries next interval.
+
+## Files to touch
+
+| Path | Change |
+|------|--------|
+| [`oeleo/connectors.py`](oeleo/connectors.py) | `ensure_connection` on Protocol + Local / SSH / SharePoint implementations |
+| [`oeleo/workers.py`](oeleo/workers.py) | Probe at `run` start + after exhausted move retry; propagate `OeleoConnectionError` |
+| [`oeleo/schedulers.py`](oeleo/schedulers.py) | Catch connection loss; notify; continue to next interval |
+| [`tests/test_oeleo.py`](tests/test_oeleo.py) (or `tests/test_ensure_connection.py`) | Unit tests with mocks as above |
+| [`README.md`](README.md) | Operator note (brief) |
+| [`.issueflows/04-designs-and-guides/code-review-correctness-and-bugs.md`](.issueflows/04-designs-and-guides/code-review-correctness-and-bugs.md) | Optional short “#8 / connection ensure” note; leave REL-02 open |
+
+## Test strategy
+
+- Command: `uv run pytest -m "not ssh"`.
+- Focused unit tests with mocked `external_connector.ensure_connection` / `move_func` (same style as #17 reconnect tests).
+- No new SSH integration case required for acceptance; optional later.
+
+## Open questions
+
+1. **After connection loss in the scheduler, sleep until next interval (recommended) or stop the whole scheduler / process?** Recommended: **sleep and retry next interval** — matches lab PCs that lose VPN/mount temporarily. Alternative: hard stop (closer to issue’s “crash if needed”).
+2. **Probe frequency:** start of `run` + after failed move-retry (recommended), or also every chunk (`n=20`)? Recommended: **start + post-failure** — enough for #8 without probing before every file.
+3. **SharePoint in this PR?** Recommended: **yes, minimal probe** so Protocol is complete; keep SharePoint logic tiny. Alternative: Local + SSH only and stub SharePoint as no-op/`NotImplemented` (weaker).
+
+## Scope check
+
+One concern, few modules, no unrelated refactors. Fits one PR. REL-02 (soft SSH list/checksum failures) and REL-04 (`sys.exit` in `die_if_necessary`) stay separate.

--- a/.issueflows/01-current-issues/issue8_status.md
+++ b/.issueflows/01-current-issues/issue8_status.md
@@ -1,0 +1,14 @@
+# Status: Issue #8
+
+- [ ] Done
+
+## What's done
+
+- Plan accepted (defaults: retry next scheduler interval; probe at run start + after failed move-retry; minimal SharePoint probe).
+
+## Remaining work
+
+- Implement `Connector.ensure_connection` (Local / SSH / SharePoint).
+- Wire Worker abort + Scheduler catch.
+- Unit tests, README note, design-doc note.
+- Run `uv run pytest -m "not ssh"`.

--- a/.issueflows/01-current-issues/issue8_status.md
+++ b/.issueflows/01-current-issues/issue8_status.md
@@ -5,10 +5,13 @@
 ## What's done
 
 - Plan accepted (defaults: retry next scheduler interval; probe at run start + after failed move-retry; minimal SharePoint probe).
+- `Connector.ensure_connection()` on Protocol + Local / SSH / SharePoint.
+- `Worker._ensure_external_connection` at `run` start and after exhausted move retry; `OeleoConnectionError` not swallowed in chunk handlers.
+- `SimpleScheduler` catches connection loss, reports, retries next interval.
+- Unit tests (local probe, abort at start, abort mid-run, continue on file-only failure, scheduler retry).
+- README operator note + design-doc note under REL-02 (partial / #8).
+- `uv run pytest -m "not ssh"` — 35 passed, 4 deselected.
 
 ## Remaining work
 
-- Implement `Connector.ensure_connection` (Local / SSH / SharePoint).
-- Wire Worker abort + Scheduler catch.
-- Unit tests, README note, design-doc note.
-- Run `uv run pytest -m "not ssh"`.
+- `/iflow-close` (mark Done, commit hygiene, PR finalize).

--- a/.issueflows/04-designs-and-guides/code-review-correctness-and-bugs.md
+++ b/.issueflows/04-designs-and-guides/code-review-correctness-and-bugs.md
@@ -117,6 +117,8 @@ Examples:
 
 **Issue size:** medium; good epic stage “harden connector errors”.
 
+**Related (partial, #8):** destination health is now probed via `Connector.ensure_connection()` at `Worker.run` start and after an exhausted move retry; lost destinations abort the run (`OeleoConnectionError`) and `SimpleScheduler` retries next interval. REL-02 soft failures for list/checksum sentinels remain open.
+
 ---
 
 ### REL-03 — Generator consumption / `file_names` lifecycle

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Core transfer settings:
 - `OELEO_DB_NAME`: sqlite database filename used for bookkeeping.
 - `OELEO_LOG_DIR`: directory for log files; defaults to the current working directory.
 - `OELEO_RECONNECT`: when `true` / `1` / `yes`, reconnect the destination connector before each changed file (useful on flaky networks). Default is off so SSH runs keep one session across files. A failed copy still reconnects once and retries regardless of this setting. Factories also accept a `reconnect=` kwarg that overrides the env var.
+- **Destination connection checks:** before each `Worker.run` (and again after a copy fails even with reconnect-retry), oeleo probes the destination via `Connector.ensure_connection()`. If the target directory/host/SharePoint library is gone, the current run aborts with `OeleoConnectionError` instead of marking every remaining file as failed. `SimpleScheduler` catches that error, reports it, and waits for the next interval so a temporary VPN/mount outage does not kill the process.
 
 SSH connector settings:
 - `OELEO_EXTERNAL_HOST`: SSH host (optionally with port, e.g. `host:2222`).

--- a/oeleo/connectors.py
+++ b/oeleo/connectors.py
@@ -74,6 +74,10 @@ class Connector(Protocol):
     def move_func(self, path: Path, to: Path, *args, **kwargs) -> bool:
         ...
 
+    def ensure_connection(self) -> None:
+        """Raise OeleoConnectionError if the destination is unreachable."""
+        ...
+
 
 class LocalConnector(Connector):
     def __init__(self, directory=None, **kwargs):
@@ -100,6 +104,25 @@ class LocalConnector(Connector):
 
     def close(self):
         pass
+
+    def ensure_connection(self) -> None:
+        path = Path(self.directory)
+        try:
+            if not path.exists() or not path.is_dir():
+                raise OeleoConnectionError(
+                    f"Local destination not available: {path}"
+                )
+            path.stat()
+            if not os.access(path, os.R_OK | os.X_OK):
+                raise OeleoConnectionError(
+                    f"Local destination not accessible: {path}"
+                )
+        except OeleoConnectionError:
+            raise
+        except OSError as e:
+            raise OeleoConnectionError(
+                f"Local destination not available: {path}"
+            ) from e
 
     def base_filter_sub_method(
         self, glob_pattern: str = "*", **kwargs
@@ -224,6 +247,30 @@ class SSHConnector(Connector):
         except Exception as e:
             log.debug(f"Got an exception during connecting: {e}")
             raise OeleoConnectionError("Could not connect")
+
+    def ensure_connection(self) -> None:
+        if self.c is None:
+            try:
+                self.connect()
+            except Exception as e:
+                raise OeleoConnectionError("Could not connect") from e
+        try:
+            remote_q = self._remote_shell_token(self.directory)
+            if self.is_posix:
+                cmd = f"test -d {remote_q}"
+            else:
+                cmd = f"if not exist {remote_q} exit /b 1"
+            result = self.c.run(cmd, hide=True, in_stream=False, warn=True)
+            if not result.ok:
+                raise OeleoConnectionError(
+                    f"Remote destination not available: {self.directory}"
+                )
+        except OeleoConnectionError:
+            raise
+        except Exception as e:
+            raise OeleoConnectionError(
+                f"Lost connection to remote destination: {self.directory}"
+            ) from e
 
     def _check_connection_and_exit(self):
         # used only when developing oeleo
@@ -435,6 +482,19 @@ class SharePointConnector(Connector):
 
     def close(self):
         self.connection.close()
+
+    def ensure_connection(self) -> None:
+        try:
+            if self.connection is None:
+                self.connect()
+            # Touch the doc library listing; any transport/auth failure aborts.
+            _ = self.connection.folder.files
+        except OeleoConnectionError:
+            raise
+        except Exception as e:
+            raise OeleoConnectionError(
+                "SharePoint destination not available"
+            ) from e
 
     def base_filter_sub_method(
         self, glob_pattern: str = "", **kwargs: Any

--- a/oeleo/schedulers.py
+++ b/oeleo/schedulers.py
@@ -9,6 +9,7 @@ from rich import print
 from rich.live import Live
 from rich.panel import Panel
 
+from oeleo.connectors import OeleoConnectionError
 from oeleo.workers import WorkerBase
 
 log = logging.getLogger("oeleo")
@@ -85,8 +86,17 @@ class SimpleScheduler(SchedulerBase):
             self.state["iterations"] += 1
             log.debug(f"ITERATING ({self.state['iterations']})")
 
-            self.worker.filter_local(additional_filters=self.additional_filters)
-            self.worker.run()
+            try:
+                self.worker.filter_local(additional_filters=self.additional_filters)
+                self.worker.run()
+            except OeleoConnectionError as e:
+                log.error(
+                    "Destination connection lost (%s); will retry next interval",
+                    e,
+                )
+                self.worker.reporter.report(
+                    f"Destination connection lost; retrying next interval ({e})"
+                )
             self._last_run = datetime.now()
             self._run_counter += 1
             next_run_at = self._last_run + timedelta(seconds=self.run_interval_time)

--- a/oeleo/workers.py
+++ b/oeleo/workers.py
@@ -20,6 +20,7 @@ from oeleo.checkers import ChecksumChecker
 from oeleo.connectors import (
     Connector,
     LocalConnector,
+    OeleoConnectionError,
     SSHConnector,
     SharePointConnector,
 )
@@ -331,6 +332,17 @@ class Worker(WorkerBase):
         )
         log.debug("<CHECK FINISHED>")
 
+    def _ensure_external_connection(self):
+        """Probe the destination; report and re-raise if unreachable."""
+        try:
+            self.external_connector.ensure_connection()
+        except OeleoConnectionError as e:
+            msg = f"Destination connection lost; aborting run ({e})"
+            self.reporter.report(msg)
+            self.reporter.notify(msg, title="error")
+            self.status = ("state", "connection-lost")
+            raise
+
     def run(self):
         """Copy the files that needs to be copied and update the db.
 
@@ -345,6 +357,7 @@ class Worker(WorkerBase):
 
         log.debug("<RUN>")
         self.die_if_necessary()
+        self._ensure_external_connection()
         self.status = ("state", "run")
         self.status = ("local_exists", False)
 
@@ -378,6 +391,8 @@ class Worker(WorkerBase):
                     failed_file = future.result()
                     if failed_file:
                         failed_files.append(failed_file)
+                except OeleoConnectionError:
+                    raise
                 except Exception as e:
                     log.error(f"Error when processing file: {e}")
         return failed_files
@@ -390,6 +405,8 @@ class Worker(WorkerBase):
                 failed_file = self._process_file(f)
                 if failed_file:
                     failed_files.append(failed_file)
+            except OeleoConnectionError:
+                raise
             except Exception as e:
                 log.error(f"Error when processing file: {e}")
                 failed_files.append(f)
@@ -434,6 +451,8 @@ class Worker(WorkerBase):
 
         self.reporter.report("!", same_line=True)
         log.debug(f"{f.name} -> {self.external_name} FAILED COPY!")
+        # File-level failure: abort the whole run only if the destination is gone.
+        self._ensure_external_connection()
         return f
 
     def _default_external_name_generator(self, f):

--- a/tests/test_oeleo.py
+++ b/tests/test_oeleo.py
@@ -7,7 +7,7 @@ import dotenv
 import pytest
 
 from oeleo import utils
-from oeleo.connectors import LocalConnector
+from oeleo.connectors import LocalConnector, OeleoConnectionError
 from oeleo.movers import simple_mover, connected_mover
 from oeleo.utils import start_logger
 from oeleo.schedulers import SimpleScheduler
@@ -336,3 +336,87 @@ def test_simple_worker_reconnect_from_env(
         reconnect=False,
     )
     assert worker_kw.reconnect is False
+
+
+def test_local_ensure_connection_ok_and_missing(tmp_path):
+    dest = tmp_path / "to"
+    dest.mkdir()
+    LocalConnector(directory=dest).ensure_connection()
+
+    missing = tmp_path / "missing"
+    with pytest.raises(OeleoConnectionError):
+        LocalConnector(directory=missing).ensure_connection()
+
+
+def test_run_aborts_when_ensure_connection_fails_at_start(tmp_path):
+    worker, external = _worker_with_mock_external(tmp_path)
+    external.ensure_connection.side_effect = OeleoConnectionError("gone")
+    files = []
+    for i in range(3):
+        f = tmp_path / "from" / f"file{i}.xyz"
+        f.write_text("data")
+        files.append(f)
+    worker.file_names = files
+
+    with pytest.raises(OeleoConnectionError):
+        worker.run()
+
+    assert external.move_func.call_count == 0
+    worker.reporter.notify.assert_called()
+
+
+def test_run_aborts_mid_run_when_connection_lost_after_failed_move(tmp_path):
+    worker, external = _worker_with_mock_external(tmp_path)
+    # Start probe OK; after the second file's exhausted retries, probe fails.
+    external.ensure_connection.side_effect = [None, OeleoConnectionError("gone")]
+    external.move_func.side_effect = [True, False, False]
+    files = []
+    for i in range(3):
+        f = tmp_path / "from" / f"file{i}.xyz"
+        f.write_text("data")
+        files.append(f)
+    worker.file_names = files
+
+    with pytest.raises(OeleoConnectionError):
+        worker.run()
+
+    # file0: one move; file1: two moves; file2 never reached
+    assert external.move_func.call_count == 3
+    assert worker.bookkeeper.update_record.call_count == 1
+
+
+def test_run_continues_when_move_fails_but_connection_ok(tmp_path):
+    worker, external = _worker_with_mock_external(tmp_path)
+    external.move_func.return_value = False
+    files = []
+    for i in range(3):
+        f = tmp_path / "from" / f"file{i}.xyz"
+        f.write_text("data")
+        files.append(f)
+    worker.file_names = files
+
+    worker.run()
+
+    assert external.move_func.call_count == 6  # two attempts per file
+    # start-of-run + once after each failed file
+    assert external.ensure_connection.call_count == 4
+
+
+def test_scheduler_retries_next_interval_after_connection_loss(tmp_path):
+    worker, external = _worker_with_mock_external(tmp_path)
+    external.ensure_connection.side_effect = OeleoConnectionError("gone")
+    f = tmp_path / "from" / "file.xyz"
+    f.write_text("data")
+    worker.file_names = [f]
+    worker.filter_local = MagicMock(return_value=[f])
+
+    s = SimpleScheduler(
+        worker,
+        run_interval_time=0.05,
+        max_run_intervals=2,
+    )
+    s.start()
+
+    assert s._run_counter == 2
+    assert external.move_func.call_count == 0
+    assert external.ensure_connection.call_count == 2


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [#8](https://github.com/ife-bat/oeleo/issues/8): stop quietly continuing transfers when the destination connection is lost.

## Changes

- Add `Connector.ensure_connection()` for Local, SSH, and SharePoint destinations (raises `OeleoConnectionError`).
- `Worker.run` probes at start; after a failed move+reconnect retry, probes again and **aborts the run** if the destination is gone (file-only failures still report `!` and continue).
- `SimpleScheduler` catches connection loss, reports it, and waits for the next interval.
- README + design-doc note; unit coverage for abort/continue/scheduler paths.

## Test plan

- [x] `uv run pytest -m "not ssh"` — 35 passed, 4 deselected
- [x] New tests: local probe, abort at start, abort mid-run, continue on file-only failure, scheduler retry

## Status

Implementation ready — run `/iflow-close` to mark done and finalize.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7443-7779-74ed-aa15-055685267f7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7443-7779-74ed-aa15-055685267f7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

