### PR TITLE
Materialize filter_local results to a list (#31)

### DIFF
--- a/.issueflows/03-solved-issues/issue31_original.md
+++ b/.issueflows/03-solved-issues/issue31_original.md
@@ -1,0 +1,20 @@
+# Issue #31: Materialize filter_local results to a list
+
+Source: https://github.com/ife-bat/oeleo/issues/31
+
+## Original issue text
+
+## Summary
+`filter_local` may leave a generator in `Worker.file_names`. `run` consumes it once; a second `run` without re-filter sees an empty iterable. `add_local` already warns about generators; `filter_local` should always materialize.
+
+**Finding ID:** REL-03  
+**Size:** yolo-fit  
+**Design doc:** `.issueflows/04-designs-and-guides/code-review-correctness-and-bugs.md`
+
+## Fix direction
+Materialize to `list` at the end of `filter_local` (and keep `file_names` as a list thereafter).
+
+## Acceptance
+- [ ] `filter_local` leaves `file_names` as a `list`
+- [ ] Second `run()` without re-filter still sees the same files
+- [ ] Unit test covers double-`run` after one `filter_local`

--- a/.issueflows/03-solved-issues/issue31_plan.md
+++ b/.issueflows/03-solved-issues/issue31_plan.md
@@ -1,0 +1,21 @@
+# Plan: Issue #31 — Materialize filter_local results to a list
+
+## Goal
+
+Ensure `Worker.filter_local` always stores a `list` in `file_names` so a second `run()` without re-filtering still sees the same files.
+
+## Approach
+
+- At end of `filter_local`, `local_files = list(...)` (same materialization as `add_local`).
+- Unit test: generator from connector → list; double-`run` after one filter still processes files.
+- Mark REL-03 done in correctness design doc.
+
+## Files to touch
+
+- `oeleo/workers.py`
+- `tests/test_filter_local_materialize.py` (new)
+- `.issueflows/04-designs-and-guides/code-review-correctness-and-bugs.md`
+
+## Test strategy
+
+`uv run pytest -m "not ssh"`

--- a/.issueflows/03-solved-issues/issue31_status.md
+++ b/.issueflows/03-solved-issues/issue31_status.md
@@ -1,0 +1,15 @@
+# Status: Issue #31
+
+- [x] Done
+
+## What's done
+
+- Yolo plan: materialize `filter_local` results with `list(...)`.
+- Implemented in `Worker.filter_local`; unit tests for generator + double-run.
+- REL-03 marked done in correctness design doc.
+- `uv run pytest -m "not ssh"` — 44 passed, 4 deselected.
+- Closed via `/iflow-close yolo`.
+
+## Remaining work
+
+- None.

--- a/.issueflows/04-designs-and-guides/code-review-correctness-and-bugs.md
+++ b/.issueflows/04-designs-and-guides/code-review-correctness-and-bugs.md
@@ -114,13 +114,11 @@ Examples:
 
 ---
 
-### REL-03 — Generator consumption / `file_names` lifecycle
+### REL-03 — Generator consumption / `file_names` lifecycle — fixed (#31)
 
-`filter_local` may leave a generator in `file_names`. `run` chunks it once; a second `run` without re-filter sees empty. `add_local` warns about generators; `filter_local` does not always materialize to `list`.
+`filter_local` now materializes connector results with `list(...)` so `file_names` survives a second `run()` without re-filtering.
 
-**Fix:** materialize to `list` in `filter_local` (tests already often use lists from local connector when extension is list; glob generators are the risk).
-
-**yolo-fit.**
+**Done.**
 
 ---
 

--- a/oeleo/workers.py
+++ b/oeleo/workers.py
@@ -204,8 +204,8 @@ class Worker(WorkerBase):
         """Selects the files that should be processed through filtering."""
         self.status = ("state", "filter-local")
         self.status = ("filtered_once", True)
-        local_files = self.local_connector.base_filter_sub_method(
-            self.extension, **kwargs
+        local_files = list(
+            self.local_connector.base_filter_sub_method(self.extension, **kwargs)
         )
 
         self.file_names = local_files

--- a/tests/test_filter_local_materialize.py
+++ b/tests/test_filter_local_materialize.py
@@ -1,0 +1,56 @@
+"""Unit tests for REL-03: filter_local materializes file_names to a list."""
+
+from unittest.mock import MagicMock, patch
+
+from oeleo.workers import simple_worker
+
+
+def test_filter_local_materializes_generator(db_tmp_path, local_tmp_path, external_tmp_path):
+    worker = simple_worker(
+        db_name=db_tmp_path,
+        base_directory_from=local_tmp_path,
+        base_directory_to=external_tmp_path,
+    )
+    paths = sorted(local_tmp_path.glob("*.xyz"))
+    assert len(paths) == 2
+
+    worker.local_connector.base_filter_sub_method = MagicMock(
+        return_value=(p for p in paths)
+    )
+
+    result = worker.filter_local()
+    assert isinstance(result, list)
+    assert isinstance(worker.file_names, list)
+    assert worker.file_names == paths
+
+    # Consuming once must not empty file_names (generator would).
+    assert list(worker.file_names) == paths
+    assert list(worker.file_names) == paths
+
+
+def test_double_run_after_one_filter_local(
+    simple_worker_with_two_matching_and_one_not_matching,
+):
+    worker = simple_worker_with_two_matching_and_one_not_matching
+
+    worker.connect_to_db()
+    worker.filter_local()
+    assert isinstance(worker.file_names, list)
+    assert len(worker.file_names) == 2
+    names = list(worker.file_names)
+
+    worker.run()
+    assert worker.file_names == names
+
+    processed = []
+
+    def track_chunk(chunk):
+        processed.extend(chunk)
+        worker.status = ("local_exists", True)
+        return []
+
+    with patch.object(worker, "_process_single_chunk", side_effect=track_chunk):
+        worker.run()
+
+    assert processed == names
+    assert len(processed) == 2


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Materialize `Worker.filter_local` results to a `list` so a second `run()` without re-filtering still sees the same files when the connector returns a generator.

Closes #31

## Changes
- `oeleo/workers.py` — `list(...)` around connector filter results
- `tests/test_filter_local_materialize.py`
- REL-03 marked done in correctness design doc

## Test plan
- [x] `filter_local` leaves `file_names` as a `list` (including generator input)
- [x] Second `run()` after one `filter_local` still iterates the same files
- [x] `uv run pytest -m "not ssh"` — 44 passed, 4 deselected

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f75fe-017f-7bbb-becb-a776f39f794d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f75fe-017f-7bbb-becb-a776f39f794d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

