### PR TITLE
Fix Worker.reporter default_factory and typing.Protocol (#35)

### DIFF
--- a/.issueflows/03-solved-issues/issue35_original.md
+++ b/.issueflows/03-solved-issues/issue35_original.md
@@ -1,0 +1,21 @@
+# Issue #35: Fix Worker.reporter default_factory and typing.Protocol import
+
+Source: https://github.com/ife-bat/oeleo/issues/35
+
+## Original issue text
+
+## Summary
+`Worker.reporter` uses a mutable dataclass default (`Reporter()`), and `workers.py` imports `Protocol` from `asyncio` instead of `typing`.
+
+**Finding IDs:** ARCH-02, ARCH-03  
+**Size:** yolo-fit  
+**Design doc:** `.issueflows/04-designs-and-guides/code-review-architecture.md`
+
+## Fix direction
+- `reporter: ReporterBase = field(default_factory=Reporter)`
+- `from typing import Protocol` (same as models/connectors)
+
+## Acceptance
+- [ ] Fresh `Worker` instances do not share one reporter object
+- [ ] Protocol import is from `typing`
+- [ ] Unit tests still pass

--- a/.issueflows/03-solved-issues/issue35_plan.md
+++ b/.issueflows/03-solved-issues/issue35_plan.md
@@ -1,0 +1,22 @@
+# Plan: Issue #35 — Reporter default_factory + typing.Protocol
+
+## Goal
+
+Stop sharing one `Reporter` across `Worker` instances, and import `Protocol` from `typing`.
+
+## Approach
+
+- `reporter: ReporterBase = field(default_factory=Reporter)`
+- Move `Protocol` into the `typing` import; drop `asyncio.Protocol`
+- Unit test: two Workers get distinct reporter objects
+- Mark ARCH-02/03 done in architecture design doc
+
+## Files to touch
+
+- `oeleo/workers.py`
+- `tests/test_worker_reporter_default.py` (new)
+- `.issueflows/04-designs-and-guides/code-review-architecture.md`
+
+## Test strategy
+
+`uv run pytest -m "not ssh"`

--- a/.issueflows/03-solved-issues/issue35_status.md
+++ b/.issueflows/03-solved-issues/issue35_status.md
@@ -1,0 +1,15 @@
+# Status: Issue #35
+
+- [x] Done
+
+## What's done
+
+- Yolo plan: `field(default_factory=Reporter)` + `typing.Protocol`.
+- Implemented in `oeleo/workers.py`; unit tests added.
+- ARCH-02/03 marked fixed in architecture design doc.
+- `uv run pytest -m "not ssh"` — 47 passed, 4 deselected.
+- Closed via `/iflow-close yolo`.
+
+## Remaining work
+
+- None.

--- a/.issueflows/04-designs-and-guides/code-review-architecture.md
+++ b/.issueflows/04-designs-and-guides/code-review-architecture.md
@@ -40,8 +40,8 @@ Codes (documented in README): `0` copy, `1` copy-if-changed, `2` never copy (loc
 | ID | Smell | Evidence | Suggestion |
 |----|-------|----------|------------|
 | ARCH-01 | Module-global Peewee proxy | `models.database_proxy` shared by all `SimpleDbHandler` instances | Per-handler `SqliteDatabase` instance; drop proxy or scope it to one process/DB |
-| ARCH-02 | Mutable dataclass default | `Worker.reporter: ReporterBase = Reporter()` | `field(default_factory=Reporter)` |
-| ARCH-03 | Wrong `Protocol` import | `from asyncio import Protocol` in `workers.py` | `from typing import Protocol` (same as models/connectors) |
+| ARCH-02 | Mutable dataclass default | ~~`Worker.reporter: ReporterBase = Reporter()`~~ — fixed (#35) | `field(default_factory=Reporter)` |
+| ARCH-03 | Wrong `Protocol` import | ~~`from asyncio import Protocol`~~ — fixed (#35) | `from typing import Protocol` (same as models/connectors) |
 | ARCH-04 | Eager connect in ctor | `Worker.__post_init__` calls `external_connector.connect()` | Connect lazily in `run`/`check` or factories; document lifecycle |
 | ARCH-05 | Env as implicit API | Many `os.environ["OELEO_…"]` KeyErrors deep in constructors | Small `Settings`/`Config` dataclass loaded once with validation + clear errors (used by factories + app) |
 | ARCH-06 | Incomplete Protocol parity | SSH additional_filters logged as unimplemented; SharePoint filter is substring `in` name | Document capability matrix; raise `NotImplementedError` or implement |

--- a/oeleo/workers.py
+++ b/oeleo/workers.py
@@ -6,11 +6,10 @@ import multiprocessing
 from multiprocessing import Process, Queue
 import os
 import sys
-from asyncio import Protocol
 from dataclasses import dataclass, field
 from math import ceil
 from pathlib import Path
-from typing import Any, Generator, Union, Callable, Iterable, List, TypeVar
+from typing import Any, Callable, Generator, Iterable, List, Protocol, TypeVar, Union
 
 from rich.panel import Panel
 from rich.text import Text
@@ -156,7 +155,7 @@ class Worker(WorkerBase):
     local_connector: Connector = None
     external_connector: Connector = None
     extension: str = None
-    reporter: ReporterBase = Reporter()
+    reporter: ReporterBase = field(default_factory=Reporter)
     external_name_generator: Callable[[Any, Path], Path] = field(default=None)
     reconnect: bool = False
     file_names: Iterable[Path] = field(init=False, default_factory=list)

--- a/tests/test_worker_reporter_default.py
+++ b/tests/test_worker_reporter_default.py
@@ -1,0 +1,33 @@
+"""Unit tests for ARCH-02/03: Worker reporter default_factory and Protocol import."""
+
+import oeleo.workers as workers_mod
+from oeleo.checkers import ChecksumChecker
+from oeleo.connectors import LocalConnector
+from oeleo.models import SimpleDbHandler
+from oeleo.workers import Worker
+
+
+def test_protocol_imported_from_typing():
+    assert workers_mod.Protocol is __import__("typing").Protocol
+
+
+def _make_worker(db_tmp_path, local_tmp_path, external_tmp_path):
+    return Worker(
+        checker=ChecksumChecker(),
+        bookkeeper=SimpleDbHandler(db_tmp_path),
+        local_connector=LocalConnector(directory=local_tmp_path),
+        external_connector=LocalConnector(directory=external_tmp_path),
+    )
+
+
+def test_workers_do_not_share_default_reporter(
+    db_tmp_path, local_tmp_path, external_tmp_path
+):
+    w1 = _make_worker(db_tmp_path, local_tmp_path, external_tmp_path)
+    w2 = _make_worker(db_tmp_path, local_tmp_path, external_tmp_path)
+    assert w1.reporter is not w2.reporter
+
+
+def test_worker_dataclass_field_uses_default_factory():
+    field_obj = Worker.__dataclass_fields__["reporter"]
+    assert field_obj.default_factory is workers_mod.Reporter


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Use `field(default_factory=Reporter)` so Workers do not share one reporter, and import `Protocol` from `typing` instead of `asyncio`.

Closes #35

## Changes
- `oeleo/workers.py`
- `tests/test_worker_reporter_default.py`
- ARCH-02/03 marked fixed in architecture design doc

## Test plan
- [x] Fresh `Worker` instances do not share one reporter object
- [x] Protocol import is from `typing`
- [x] `uv run pytest -m "not ssh"` — 47 passed, 4 deselected

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f75fe-017f-7bbb-becb-a776f39f794d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f75fe-017f-7bbb-becb-a776f39f794d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

