### PR TITLE
Delete base_filter_old and unused workers imports (#36)

### DIFF
--- a/.issueflows/03-solved-issues/issue36_original.md
+++ b/.issueflows/03-solved-issues/issue36_original.md
@@ -1,0 +1,20 @@
+# Issue #36: Delete base_filter_old and unused imports
+
+Source: https://github.com/ife-bat/oeleo/issues/36
+
+## Original issue text
+
+## Summary
+`filters.py` still has `base_filter_old`, and `workers.py` carries unused imports (`multiprocessing`, Rich `Panel`/`Text`, `ceil`, …). Dead code noise for agents and readers.
+
+**Finding ID:** CLEAN-01  
+**Size:** yolo-fit  
+**Design doc:** `.issueflows/04-designs-and-guides/code-review-architecture.md`
+
+## Fix direction
+Confirm `base_filter_old` is unused, delete it, and trim clearly unused imports in files you touch. No behavior change.
+
+## Acceptance
+- [ ] `base_filter_old` removed
+- [ ] Unused imports cleaned in touched modules
+- [ ] `uv run pytest -m "not ssh"` green

--- a/.issueflows/03-solved-issues/issue36_plan.md
+++ b/.issueflows/03-solved-issues/issue36_plan.md
@@ -1,0 +1,22 @@
+# Plan: Issue #36 — Delete base_filter_old and unused imports
+
+## Goal
+
+Remove dead `base_filter_old` and unused imports in touched modules with no behavior change.
+
+## Approach
+
+- Delete `base_filter_old` from `filters.py` (confirmed unused).
+- Trim unused imports from `workers.py`: multiprocessing/Process/Queue, ceil, Rich Panel/Text/Progress helpers, unused `Generator` typing.
+- Mark CLEAN-01 items done in architecture design doc.
+- Rely on existing unit suite (no behavior tests needed).
+
+## Files to touch
+
+- `oeleo/filters.py`
+- `oeleo/workers.py`
+- `.issueflows/04-designs-and-guides/code-review-architecture.md`
+
+## Test strategy
+
+`uv run pytest -m "not ssh"`

--- a/.issueflows/03-solved-issues/issue36_status.md
+++ b/.issueflows/03-solved-issues/issue36_status.md
@@ -1,0 +1,14 @@
+# Status: Issue #36
+
+- [x] Done
+
+## What's done
+
+- Yolo plan: delete `base_filter_old`; trim unused `workers.py` imports.
+- Implemented; CLEAN-01 rows marked in architecture design doc.
+- `uv run pytest -m "not ssh"` — 47 passed, 4 deselected.
+- Closed via `/iflow-close yolo`.
+
+## Remaining work
+
+- None.

--- a/.issueflows/04-designs-and-guides/code-review-architecture.md
+++ b/.issueflows/04-designs-and-guides/code-review-architecture.md
@@ -57,9 +57,9 @@ Codes (documented in README): `0` copy, `1` copy-if-changed, `2` never copy (loc
 
 | Item | Location | Action |
 |------|----------|--------|
-| `base_filter_old` | `filters.py` | Delete once confirmed unused |
+| ~~`base_filter_old`~~ | `filters.py` | Removed (#36) |
 | `_check_connection_and_exit` + `check_connection_and_exit` | `SSHConnector` | Keep one debug helper or move to `check/` playground |
-| Unused imports in `workers.py` | `multiprocessing`, `Panel`, `Text`, `ceil`, … | Trim when touching file |
+| ~~Unused imports in `workers.py`~~ | `multiprocessing`, `Panel`, `Text`, `ceil`, … | Trimmed (#36) |
 | Dual consoles | `console.py` `simple_console` vs `console` | Merge or document why both exist |
 | `main.py` as scratchpad | hard-coded developer paths | Keep examples generic or move to `docs/examples/` |
 | Mix of `log` / `logging` / `print` | connectors, movers, reporters | Standardize on `log = logging.getLogger("oeleo")` |

--- a/oeleo/filters.py
+++ b/oeleo/filters.py
@@ -67,25 +67,6 @@ FilterFunction = Any
 FilterTuple = Any  # tuple[str, FilterFunction] for py3.10
 
 
-def base_filter_old(
-    path: Path,
-    extension: str = None,
-    additional_filters: Iterable[FilterTuple] = None,
-    base_filter_func: Any = None,
-) -> Union[Generator[Path, None, None], Iterable[Path]]:
-    """Simple directory content filter - cannot be used for ssh"""
-
-    if base_filter_func is None:
-        base_filter_func = path.glob
-
-    file_list = base_filter_func(f"*{extension}")
-
-    if additional_filters is not None:
-        file_list = additional_filtering(file_list, additional_filters)
-
-    return file_list
-
-
 def base_filter(
     path: Path,
     extension: str = None,

--- a/oeleo/workers.py
+++ b/oeleo/workers.py
@@ -2,18 +2,11 @@ from collections import deque
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 import logging
-import multiprocessing
-from multiprocessing import Process, Queue
 import os
 import sys
 from dataclasses import dataclass, field
-from math import ceil
 from pathlib import Path
-from typing import Any, Callable, Generator, Iterable, List, Protocol, TypeVar, Union
-
-from rich.panel import Panel
-from rich.text import Text
-from rich.progress import Progress, SpinnerColumn, TextColumn
+from typing import Any, Callable, Iterable, List, Protocol, TypeVar, Union
 
 from oeleo.checkers import ChecksumChecker
 from oeleo.connectors import (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Remove unused `base_filter_old` and trim dead imports in `workers.py`. No behavior change.

Closes #36

## Changes
- `oeleo/filters.py` — delete `base_filter_old`
- `oeleo/workers.py` — drop unused multiprocessing / Rich / `ceil` / `Generator` imports
- CLEAN-01 rows marked done in architecture design doc

## Test plan
- [x] `base_filter_old` removed
- [x] Unused imports cleaned in touched modules
- [x] `uv run pytest -m "not ssh"` — 47 passed, 4 deselected

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f75fe-017f-7bbb-becb-a776f39f794d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f75fe-017f-7bbb-becb-a776f39f794d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

