### PR TITLE
Remove broken SharePoint reconnect helper and __delete__ hooks (#34)

### DIFF
--- a/.issueflows/03-solved-issues/issue34_original.md
+++ b/.issueflows/03-solved-issues/issue34_original.md
@@ -1,0 +1,22 @@
+# Issue #34: Remove broken SharePoint reconnect helper and connector __delete__ hooks
+
+Source: https://github.com/ife-bat/oeleo/issues/34
+
+## Original issue text
+
+## Summary
+`SharePointConnection.reconnect` calls a missing `connect()` method (footgun). Connector `__delete__` hooks are not Python finalizers (`__del__`) and are dead/wrong. Prefer cleanup via context managers later; for now remove the broken helpers.
+
+**Finding IDs:** BUG-06, CLEAN  
+**Size:** yolo-fit  
+**Design doc:** `.issueflows/04-designs-and-guides/code-review-correctness-and-bugs.md` and `code-review-architecture.md`
+
+## Fix direction
+- Delete or fix `SharePointConnection.reconnect` (connector Protocol `reconnect` already goes through `SharePointConnector.connect`)
+- Remove unused `__delete__` methods on connectors
+- Do not expand into a full context-manager rewrite in this issue
+
+## Acceptance
+- [ ] Broken SharePoint helper is gone or works
+- [ ] No `__delete__` hooks left on connectors
+- [ ] Existing unit tests still pass (`uv run pytest -m "not ssh"`)

--- a/.issueflows/03-solved-issues/issue34_plan.md
+++ b/.issueflows/03-solved-issues/issue34_plan.md
@@ -1,0 +1,23 @@
+# Plan: Issue #34 — Remove broken SharePoint reconnect / `__delete__`
+
+## Goal
+
+Remove the broken `SharePointConnection.reconnect` footgun and dead connector `__delete__` hooks without a context-manager rewrite.
+
+## Approach
+
+- Delete `SharePointConnection.reconnect` (Protocol `SharePointConnector.reconnect` → `close`+`connect` remains).
+- Delete `__delete__` on `SSHConnector` and `SharePointConnector`.
+- Unit test: helpers absent; suite still green.
+- Mark BUG-06 / destructor note done in design docs.
+
+## Files to touch
+
+- `oeleo/connectors.py`
+- `tests/test_connector_cleanup_hooks.py` (new)
+- `.issueflows/04-designs-and-guides/code-review-correctness-and-bugs.md`
+- `.issueflows/04-designs-and-guides/code-review-architecture.md`
+
+## Test strategy
+
+`uv run pytest -m "not ssh"`

--- a/.issueflows/03-solved-issues/issue34_status.md
+++ b/.issueflows/03-solved-issues/issue34_status.md
@@ -1,0 +1,15 @@
+# Status: Issue #34
+
+- [x] Done
+
+## What's done
+
+- Yolo plan: remove broken SharePointConnection.reconnect and connector `__delete__` hooks.
+- Implemented in `oeleo/connectors.py`; unit tests added.
+- BUG-06 / destructor notes updated in design docs.
+- `uv run pytest -m "not ssh"` — 49 passed, 4 deselected.
+- Closed via `/iflow-close yolo`.
+
+## Remaining work
+
+- None.

--- a/.issueflows/04-designs-and-guides/code-review-architecture.md
+++ b/.issueflows/04-designs-and-guides/code-review-architecture.md
@@ -50,7 +50,7 @@ Codes (documented in README): `0` copy, `1` copy-if-changed, `2` never copy (loc
 
 1. **Extension type:** factories type `extension: str` but `base_filter` accepts `list` of extensions (`main.simple_multi_dir` passes a list). Typing/docs should allow `str | list[str]`.
 2. **`register_password`:** name implies “set password”; implementation only prompts when `pwd is None` and never assigns a provided password (**BUG-05**).
-3. **Destructor misuse:** `__delete__` on connectors is not a Python finalizer (`__del__`). Dead/wrong hook — remove or replace with context manager (`__enter__`/`__exit__`).
+3. **Destructor misuse:** ~~`__delete__` on connectors~~ — removed (#34). Prefer context managers (`__enter__`/`__exit__`) if cleanup hooks are needed later.
 4. **`connected_mover`:** thin wrapper rarely used by `Worker` (worker calls `connector.move_func` directly). Keep as public helper or demote to tests.
 
 ## Dead / duplicate / inconsistent code (CLEAN-*)

--- a/.issueflows/04-designs-and-guides/code-review-correctness-and-bugs.md
+++ b/.issueflows/04-designs-and-guides/code-review-correctness-and-bugs.md
@@ -83,17 +83,11 @@ processed_date = peewee.DateTimeField(default=datetime.datetime.now())
 
 ---
 
-### BUG-06 — `SharePointConnection.reconnect` broken
+### BUG-06 — `SharePointConnection.reconnect` broken — fixed (#34)
 
-```python
-def reconnect(self, **kwargs) -> None:
-    self.close()
-    self.connect()  # method does not exist on SharePointConnection
-```
+Removed broken `SharePointConnection.reconnect` (called missing `connect()`). Connector `__delete__` hooks removed (not Python finalizers). `SharePointConnector` still reconnects via Protocol `close`+`connect`.
 
-If anything calls this helper’s `reconnect`, it fails. `SharePointConnector.reconnect` uses Protocol default → `SharePointConnector.connect` (OK). Dead/broken helper still a footgun.
-
-**yolo-fit** cleanup.
+**Done.**
 
 ---
 

--- a/oeleo/connectors.py
+++ b/oeleo/connectors.py
@@ -323,10 +323,6 @@ class SSHConnector(Connector):
     def close(self):
         self.c.close()
 
-    def __delete__(self, instance):
-        if self.c is not None:
-            self.c.close()
-
     def base_filter_sub_method(self, glob_pattern: str = "", **kwargs: Any) -> list:
         log.debug("base filter function for SSHConnector")
         log.debug("got this glob pattern:")
@@ -453,10 +449,6 @@ class SharePointConnection:
     def close(self):
         pass
 
-    def reconnect(self, **kwargs) -> None:
-        self.close()
-        self.connect()
-
 
 class SharePointConnector(Connector):
     def __init__(
@@ -483,10 +475,6 @@ class SharePointConnector(Connector):
         text += f"{self.connection=}\n"
 
         return text
-
-    def __delete__(self, instance):
-        if self.connection is not None:
-            self.connection.close()
 
     def connect(self, **kwargs) -> None:
         self.connection = SharePointConnection(

--- a/tests/test_connector_cleanup_hooks.py
+++ b/tests/test_connector_cleanup_hooks.py
@@ -1,0 +1,13 @@
+"""Unit tests for BUG-06: remove broken SharePoint reconnect / __delete__ hooks."""
+
+import oeleo.connectors as connectors
+
+
+def test_sharepoint_connection_has_no_reconnect():
+    assert not hasattr(connectors.SharePointConnection, "reconnect")
+
+
+def test_connectors_have_no_delete_hooks():
+    assert not hasattr(connectors.SSHConnector, "__delete__")
+    assert not hasattr(connectors.SharePointConnector, "__delete__")
+    assert not hasattr(connectors.LocalConnector, "__delete__")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Remove the broken `SharePointConnection.reconnect` footgun (calls missing `connect()`) and dead connector `__delete__` hooks that are not Python finalizers.

Closes #34

## Changes
- `oeleo/connectors.py` — delete `SharePointConnection.reconnect`, `SSHConnector.__delete__`, `SharePointConnector.__delete__`
- `tests/test_connector_cleanup_hooks.py`
- BUG-06 / destructor notes updated in design docs

## Test plan
- [x] Broken SharePoint helper is gone
- [x] No `__delete__` hooks left on connectors
- [x] `uv run pytest -m "not ssh"` — 49 passed, 4 deselected

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f75fe-017f-7bbb-becb-a776f39f794d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f75fe-017f-7bbb-becb-a776f39f794d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

