### PR TITLE
Raise on SSH list/checksum failure instead of empty/False sentinels (#39)

### DIFF
--- a/.issueflows/01-current-issues/issue39_original.md
+++ b/.issueflows/01-current-issues/issue39_original.md
@@ -1,0 +1,23 @@
+# Issue #39: Raise on SSH list/checksum failure instead of empty/False sentinels
+
+Source: https://github.com/ife-bat/oeleo/issues/39
+
+## Original issue text
+
+## Summary
+Soft connector failures become silent skips: SSH `_list_content` catches exceptions and returns `[]`; `calculate_checksum` logs “should raise” but still parses stdout; SharePoint checksum returns `False` on error. Empty remote listing can look like “no files” and drive wrong sync decisions.
+
+**Finding ID:** REL-02  
+**Size:** standard  
+**Design doc:** `.issueflows/04-designs-and-guides/code-review-correctness-and-bugs.md`
+
+## Related
+Destination health probes from #8 (`ensure_connection`) are separate. This issue is about list/checksum error semantics, not connection-lost abort.
+
+## Fix direction
+Typed exceptions (`OeleoConnectionError` / `OeleoTransferError`); fail the run or per-file with `reporter.notify`; never return sentinel `False` as a checksum or treat list failure as empty success.
+
+## Acceptance
+- [ ] SSH list failure does not look like an empty directory without error status
+- [ ] Checksum failures raise or surface via reporter (no `False` sentinel)
+- [ ] Unit tests cover negative paths (mock failures)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Captures GitHub issue #39 (REL-02) under `.issueflows/01-current-issues/` to start the issue-flow lifecycle.
- Implementation not started yet — next step is `/iflow-plan` once confirmed.

## Context
Soft connector failures currently become silent skips: SSH `_list_content` returns `[]` on exception; checksum paths use `False`/parsed stdout sentinels. This PR will raise typed errors and surface them via the reporter (distinct from #8 `ensure_connection`).

## Test plan
- [ ] Plan confirmed via `/iflow-plan`
- [ ] Unit tests for SSH list/checksum negative paths (mocks)
- [ ] `uv run pytest -m "not ssh"`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f76e7-2000-7840-a0b9-9e1c0b905bcf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f76e7-2000-7840-a0b9-9e1c0b905bcf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

